### PR TITLE
Return integer or float in captures

### DIFF
--- a/lib/cabbage/feature.ex
+++ b/lib/cabbage/feature.ex
@@ -243,8 +243,16 @@ defmodule Cabbage.Feature do
     expression
     |> Cabbage.Feature.CucumberExpressions.to_regex()
     |> Regex.named_captures(step_text)
-    |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
+    |> Enum.map(&convert_types(&1, expression))
     |> Enum.into(%{})
+  end
+
+  defp convert_types({k, v}, expression) when is_binary(expression) do
+    {String.to_atom(k), Cabbage.Feature.MaybeNumber.parse(v)}
+  end
+
+  defp convert_types({k, v}, _expression) do
+    {String.to_atom(k), v}
   end
 
   @doc """

--- a/lib/cabbage/feature/parameter_type.ex
+++ b/lib/cabbage/feature/parameter_type.ex
@@ -10,3 +10,13 @@ defmodule Cabbage.Feature.ParameterType do
     ]
   end
 end
+
+defmodule Cabbage.Feature.MaybeNumber do
+  def parse(str) do
+    cond do
+      Regex.match?(~r/^\d+$/, str) -> String.to_integer(str)
+      Regex.match?(~r/^\d+\.\d+$/, str) -> String.to_float(str)
+      true -> str
+    end
+  end
+end

--- a/test/cucumber_expressions_test.exs
+++ b/test/cucumber_expressions_test.exs
@@ -33,8 +33,8 @@ defmodule Cabbage.CucumberExpressionsTest do
   end
 
   defthen ~r/^Named captures are of expected type$/, _, %{count: count, quantity: quantity, word_count: word_count, matched_str: matched_str} do
-    assert count == "1"
-    assert quantity == "1.0"
+    assert count == 1
+    assert quantity == 1.0
     assert word_count == "one"
     assert matched_str == "\"one simple\""
     {:ok, %{}}


### PR DESCRIPTION
In order to save us from calling `String.to_integer/1` or
`String.to_float/1` in our step definition for values which are integers
or floats.

So far it's a quick `check the concept` implementation, which is a good
point to stop for a discussion. Once we agreed that this feature make
sense we can go and tidy it up.

Note: this feature is only available for Cucumber Expressions, as we
want to be backwards compatible and don't introduce breaking changes :)